### PR TITLE
Fix zigics module usage in native example

### DIFF
--- a/examples/native/README.md
+++ b/examples/native/README.md
@@ -1,0 +1,39 @@
+# Native zigics example
+
+This example shows how to integrate the `zigics` physics package in a native
+Zig application alongside the [raylib](https://www.raylib.com/) bindings.
+
+## Building
+
+Ensure `zig` is installed on your system. From this directory run:
+
+```
+zig build run
+```
+
+## Using zigics in your own project
+
+1. Add `zigics` to `build.zig.zon`:
+
+```zig
+.dependencies = .{
+    .zigics = .{ .path = "../.." },
+};
+```
+
+2. In `build.zig` obtain the module from the dependency and add it to your
+   executable:
+
+```zig
+const zigics_dep = b.dependency("zigics", .{ .target = target, .optimize = optimize });
+const zigics_mod = zigics_dep.module("zigics");
+exe.root_module.addImport("zigics", zigics_mod);
+```
+
+3. Import `zigics` in your source files:
+
+```zig
+const zigics = @import("zigics");
+```
+
+See `src/main.zig` for a minimal example that verifies the package linkage.

--- a/examples/native/build.zig
+++ b/examples/native/build.zig
@@ -28,10 +28,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
-
-    const zigics_mod = b.addModule("zigics", .{
-        .root_source_file = zigics_dep.path("src/core/zigics.zig"),
-    });
+    const zigics_mod = zigics_dep.module("zigics");
 
     exe.root_module.addImport("zigics", zigics_mod);
 

--- a/examples/native/src/main.zig
+++ b/examples/native/src/main.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const rl = @import("raylib");
+const zigics = @import("zigics");
 
 const WINDOW_WIDTH = 1280;
 const WINDOW_HEIGHT = 900;
@@ -7,6 +8,10 @@ const WINDOW_HEIGHT = 900;
 pub fn main() !void {
     rl.initWindow(WINDOW_WIDTH, WINDOW_HEIGHT, "zigics");
     defer rl.closeWindow();
+
+    // Access zigics types to verify package integration
+    const Vector2 = zigics.nmath.Vector2;
+    var _origin = Vector2{ .x = 0, .y = 0 };
 
     while (!rl.windowShouldClose()) {
         rl.beginDrawing();


### PR DESCRIPTION
## Summary
- load `zigics` via dependency module rather than re-adding it
- demonstrate module import in native example source
- document how to consume `zigics` in the native example

## Testing
- `zig fmt build.zig src/main.zig` *(fails: command not found)*
- `zig build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a76bb8f3808320a6463073ba6a53f1